### PR TITLE
Add HPSC QEMU BSP and interface definitions

### DIFF
--- a/tester/rtems/testing/bsps/gen_r52_qemu.ini
+++ b/tester/rtems/testing/bsps/gen_r52_qemu.ini
@@ -1,0 +1,39 @@
+#
+# RTEMS Tools Project (http://www.rtems.org/)
+# Copyright 2019 Kinsey Moore (kinsey.moore@oarcorp.com)
+# All rights reserved.
+#
+# This file is part of the RTEMS Tools package in 'rtems-tools'.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# The HPSC Cortex-R52 QEMU BSP
+#
+[gen_r52_qemu]
+bsp                       = gen_r52_qemu
+arch                      = arm
+tester                    = %{_rtscripts}/qemu_r52_hpsc.cfg
+bsp_qemu_hpsc_relase_path = /opt/HPSC_3.0
+timeout                   = 300

--- a/tester/rtems/testing/qemu_r52_hpsc.cfg
+++ b/tester/rtems/testing/qemu_r52_hpsc.cfg
@@ -1,0 +1,97 @@
+#
+# RTEMS Tools Project (http://www.rtems.org/)
+# Copyright 2019 Kinsey Moore (kinsey.moore@oarcorp.com)
+# All rights reserved.
+#
+# This file is part of the RTEMS Tools package in 'rtems-tools'.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# QEMU
+#
+# Use a qemu command to run the executable in the qemu simulator.
+#
+
+%include %{_configdir}/base.cfg
+%include %{_configdir}/checks.cfg
+
+#
+# Console.
+#
+%define console_stdio
+%include %{_configdir}/console.cfg
+
+#
+# RTEMS version
+#
+%include %{_rtdir}/rtems/version.cfg
+
+#
+# Coverage, some builds of qemu support coverage.
+#
+%if %{defined coverage}
+ %define qemu_use_serial_console
+%endif
+
+%define qemu_bsp_path %{bsp_qemu_hpsc_relase_path}/BSP
+
+# common to all QEMU releases
+%define qemu_dtb -hw-dtb %{qemu_bsp_path}/hpsc-arch.dtb
+%define qemu_opts_base -machine arm-generic-fdt -nographic -serial null -serial mon:stdio -serial null
+%define qemu_r52_uboot -device loader,addr=0x60000000,file=%{qemu_bsp_path}/rtps-r52/u-boot.bin,force-raw,cpu-num=1
+%define qemu_r52_exec -device loader,addr=0x68000000,file=%{test_executable},force-raw,cpu-num=1
+%define qemu_hpps_firmware -device loader,addr=0x80000000,file=%{qemu_bsp_path}/hpps/arm-trusted-firmware.bin,force-raw,cpu-num=4
+%define qemu_hpps_uboot -device loader,addr=0x80020000,file=%{qemu_bsp_path}/hpps/u-boot.bin,force-raw,cpu-num=4
+%define qemu_hpps_dtb -device loader,addr=0x84000000,file=%{qemu_bsp_path}/hpps/hpsc.dtb,force-raw,cpu-num=4
+%define qemu_hpps_uimage -device loader,addr=0x81080000,file=%{qemu_bsp_path}/uImage.0,force-raw,cpu-num=4
+%define qemu_hpps_cpio -device loader,addr=0x90000000,file=%{qemu_bsp_path}/hpps/core-image-hpsc-hpsc-chiplet.cpio.gz.u-boot,force-raw,cpu-num=4
+%define qemu_trch_exec -device loader,file=%{qemu_bsp_path}/trch/trch.elf,cpu-num=0
+
+# for HPSC QEMU release 2.x
+
+#%define qemu_device_extra -device loader,addr=0x000ff000,data=0x00000002,data-len=4,cpu-num=0 -device loader,addr=0x000ff004,data=0x00000001,data-len=4,cpu-num=0 -device loader,addr=0x9f000000,data=0x00000000,data-len=4,cpu-num=4
+
+# for HPSC QEMU release 3.0
+%define qemu_device_extra -drive file=%{qemu_bsp_path}/rootfs_nand.bin.0,if=pflash,format=raw,index=3 -drive file=%{qemu_bsp_path}/hpps_sram.bin.0,if=pflash,format=raw,index=2 -drive file=%{qemu_bsp_path}/trch_sram.bin.0,if=pflash,format=raw,index=0
+
+%define qemu_devices %{qemu_r52_uboot} %{qemu_r52_exec} %{qemu_hpps_firmware} %{qemu_hpps_uboot} %{qemu_hpps_dtb} %{qemu_hpps_cpio} %{qemu_hpps_uimage} %{qemu_trch_exec} %{qemu_device_extra}
+
+#
+# Qemu executable
+#
+%ifn %{defined bsp_qemu_opts}
+ %define bsp_qemu_opts %{nil}
+%endif
+%ifn %{defined bsp_qemu_cov_opts}
+ %define bsp_qemu_cov_opts %{nil}
+%endif
+
+%define qemu_cmd %{qemu_bsp_path}/qemu-system-aarch64
+%define qemu_opts %{bsp_qemu_opts} %{bsp_qemu_cov_opts} %{qemu_opts_base} %{qemu_dtb} %{qemu_devices}
+
+#
+# Executable
+#
+%execute %{qemu_cmd} %{qemu_opts}


### PR DESCRIPTION
Add the BSP config and QEMU interface definition for the HPSC
Cortex-R52. This can not be handled by a normal QEMU definition due to
the complex device tree present in this project.